### PR TITLE
Ballchasy

### DIFF
--- a/DevSetup-VSCode.md
+++ b/DevSetup-VSCode.md
@@ -26,8 +26,16 @@ This set of instructions informs developers how to configure their dev environme
         - `.[style]` is a literal value
         - `.[dev]` or `.[style]` may be used
 
+<br>
 
-1. Follow the "Installing Red" section Redbot's [official documentation](https://docs.discord.red/en/stable/install_guides/windows.html#installing-red).
+1. Follow the "Installing Red" section Redbot's [official documentation](https://docs.discord.red/en/stable/install_guides/windows.html#installing-red):
+
+    ```
+    python -m pip install -U pip setuptools wheel
+    python -m pip install -U Red-DiscordBot
+    ```
+
+    If running the code in debug mode is failing, you may need to re-execute these installation steps.
 
 1. Enter Virtual Environment with:
 

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -212,17 +212,17 @@ class BCManager(commands.Cog):
 # region player commands 
     @commands.command(aliases=['bcr', 'bcpull'])
     @commands.guild_only()
-    async def bcreport(self, ctx): # , team_name=None, match_day=None):
+    async def bcreport(self, ctx, match_day: int=None): # , team_name=None, match_day=None):
         """Finds match games from recent public uploads, and adds them to the correct Ballchasing subgroup
         """        
-        await self.process_bcreport(ctx)
+        await self.process_bcreport(ctx, match_day=match_day)
     
     @commands.command(aliases=['fbcr', 'fbcpull'])
     @commands.guild_only()
-    async def forcebcreport(self, ctx): # , team_name=None, match_day=None):
+    async def forcebcreport(self, ctx, match_day: int=None): # , team_name=None, match_day=None):
         """Finds match games from recent public uploads, and adds them to the correct Ballchasing subgroup
         """        
-        await self.process_bcreport(ctx, True)
+        await self.process_bcreport(ctx, True, match_day=match_day)
     
     @commands.command(aliases=['bcGroup', 'ballchasingGroup', 'bcg'])
     @commands.guild_only()
@@ -254,10 +254,10 @@ class BCManager(commands.Cog):
             if token:
                 self.ballchasing_api[guild] = ballchasing.Api(token)
 
-    async def process_bcreport(self, ctx, force=False):
+    async def process_bcreport(self, ctx, force=False, match_day: int=None):
         # Step 1: Find Match
         player = ctx.author
-        matches = await self.get_matches(ctx, player)
+        matches = await self.get_matches(ctx, player, match_day=match_day)
         if not matches:
             return await ctx.send(":x: No matches found.")
         

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -58,7 +58,7 @@ class BCManager(commands.Cog):
     @commands.command(aliases=['setAuthKey'])
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def setAuthToken(self, ctx, auth_token):
+    async def setBCAuthToken(self, ctx, auth_token):
         """Sets the Auth Key for Ballchasing API requests.
         Note: Auth Token must be generated from the Ballchasing group owner
         """
@@ -79,6 +79,13 @@ class BCManager(commands.Cog):
                 return await ctx.send(f":white_check_mark: {DONE}")
 
         await ctx.send(":x: The Auth Token you've provided is invalid.")
+
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def setTopLevelGroup(self, ctx, rsc_app_token):
+        await self._save_rsc_app_token(self, ctx.guild, rsc_app_token)
+        await ctx.reply(DONE)
 
     @commands.command(aliases=['setLeagueSeasonGroup', 'stlg'])
     @commands.guild_only()
@@ -1426,7 +1433,7 @@ class BCManager(commands.Cog):
         url =  f"{RSC_WEB_APP}/api/member/{player.id}/accounts"
         rsc_app_token: str = await self._get_rsc_app_token(player.guild)
         headers = {"X-Api-Key": rsc_app_token}
-        data = requests.get(url, headers=headers).json()
+        data = (await asyncio.to_thread(requests.get, url, headers=headers)).json()
         accounts = data.get('accounts', [])
         
         if not platforms:

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -140,7 +140,7 @@ class BCManager(commands.Cog):
     @commands.command()
     @commands.guild_only()
     async def getBCLogChannel(self, ctx):
-        if not self.has_perms(ctx.author):
+        if not await self.has_perms(ctx.author):
             return
         channel: discord.Channel = await self._get_log_channel(ctx.guild)
         await ctx.reply(channel.mention)
@@ -148,7 +148,7 @@ class BCManager(commands.Cog):
     @commands.command()
     @commands.guild_only()
     async def getStatsManagerRole(self, ctx):
-        if not self.has_perms(ctx.author):
+        if not await self.has_perms(ctx.author):
             return
         role: discord.Role = await self._get_stats_manager_role(ctx.guild)
         await ctx.reply(role.mention)
@@ -159,7 +159,7 @@ class BCManager(commands.Cog):
     @commands.command(aliases=['reportAllMatches', 'ram'])
     @commands.guild_only()
     async def reportMatches(self, ctx, match_day: int=None):
-        if not self.has_perms(ctx.author):
+        if not await self.has_perms(ctx.author):
             return
         log.debug("Reporting matches...")
         if not match_day:
@@ -240,7 +240,7 @@ class BCManager(commands.Cog):
     @commands.command(aliases=['rff', 'reportFF'])
     @commands.guild_only()
     async def reportForfeits(self, ctx, match_day, team_a, team_b):
-        if not self.has_perms(ctx.author):
+        if not await self.has_perms(ctx.author):
             return
         match = await self.get_matchup(ctx, match_day, team_a, team_b)
         if not match:
@@ -269,7 +269,7 @@ class BCManager(commands.Cog):
     @commands.command(aliases=['mmr'])
     @commands.guild_only()
     async def missingMatchReport(self, ctx):
-        if not self.has_perms(ctx.author):
+        if not await self.has_perms(ctx.author):
             return
         await self.process_missing_replays(ctx) #, all_missing_replays)  
 
@@ -281,7 +281,7 @@ class BCManager(commands.Cog):
         Example:
         [p]manualMatchReport 4 Gorillas 3 Peppermint 1
         """
-        if not self.has_perms(ctx.author):
+        if not await self.has_perms(ctx.author):
             return
         match = await self.get_matchup(ctx, match_day, team_a, team_b)
 
@@ -325,7 +325,7 @@ class BCManager(commands.Cog):
     @commands.command(aliases=['mmu', 'manuallyUpdateMatch', 'mum'])
     @commands.guild_only()
     async def manualMatchUpdate(self, ctx, match_day: int, bc_match_link_or_id):
-        if not self.has_perms(ctx.author):
+        if not await self.has_perms(ctx.author):
             return
         match_code = self.parse_group_code(bc_match_link_or_id)
         

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -224,7 +224,6 @@ class BCManager(commands.Cog):
 
         deep_match_report, embed = await self.get_score_deep_summary_and_embed(ctx, match, status="active")
         message = await ctx.reply(embed=embed)
-        await self.assign_ff_reactions(message, deep_match_report)
         
         msg_val = { 
             "message": message,
@@ -235,6 +234,8 @@ class BCManager(commands.Cog):
         }
 
         self.ffp.setdefault(ctx.guild, {}).setdefault(message, msg_val)
+        
+        await self.assign_ff_reactions(message, deep_match_report)
 
 
     @commands.command(aliases=['mmr'])

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -544,7 +544,9 @@ class BCManager(commands.Cog):
 
         if forfeits:
             embed.add_field(name="Forfeited Games", value="\n".join([f"{ff['team']} FF Game {ff['game_no']}" for ff in forfeits]), inline=True)
-        
+        else:
+            embed.add_field(name="Forfeited Games", value="[No Games Currently Forfeited]")
+            
         if status == "active":
             embed.add_field(name="Instructions", value="React to report match games as forfeited.\nReact with :white_check_mark: to confirm, or :negative_squared_cross_mark: to cancel.",
             inline=False)

--- a/bcManager/info.json
+++ b/bcManager/info.json
@@ -2,7 +2,7 @@
     "author" : ["RSC Development Committee"],
     "description" : "A ballchasing integration with Rocket Soccar Confederation (RSC) for league match replay management and score reporting.",
     "short" : "RSC ballchasing integration.",
-    "requirements" : ["python-ballchasing"],
+    "requirements" : ["python-ballchasing", "py-cord"],
     "permissions" : [],
     "tags" : ["RSC"],
     "min_python_version": [3, 9, 0]

--- a/match/match.py
+++ b/match/match.py
@@ -123,8 +123,7 @@ class Match(commands.Cog):
         """
         schedule = await self._schedule(ctx)
         dump = json.dumps(schedule, indent=4, sort_keys=True)
-        await ctx.send("Here is all of the schedule data in "
-                       "JSON format.\n```json\n{0}\n```".format(dump))
+        await ctx.send("Here is all of the schedule data in JSON format.\n```json\n{0}\n```".format(dump))
 
     @commands.command()
     @commands.guild_only()
@@ -701,6 +700,18 @@ class Match(commands.Cog):
             if match_matches_match_i:
                 return i 
         return None 
+
+    async def get_unreported_matches(self, ctx):
+        schedule = await self._schedule(ctx)
+        missing_matches = {}
+        for tier, match_day_matches in schedule.items():
+            for match_day, matches in match_day_matches.items():
+                for match in matches:
+                    if not match.get("report"):
+                        missing_tier_matches = missing_matches.setdefault(tier, [])
+                        missing_tier_matches.append(match)
+                        missing_matches[tier] = missing_tier_matches
+        return missing_matches
 
 # json
     async def _schedule(self, ctx):

--- a/match/match.py
+++ b/match/match.py
@@ -284,8 +284,7 @@ class Match(commands.Cog):
 # Helper Functions
     async def _add_match(self, ctx, match_day, match_date, home, away, match_type, match_format):
         """Does the actual work to save match data."""
-        # Process inputs to normalize the data (e.g. convert team names to
-        # roles)
+        # Process inputs to normalize the data (e.g. convert team names to roles)
         match_date_error = None
         try:
             datetime.strptime(match_date, '%B %d, %Y').date()

--- a/match/misc/example_settings.json
+++ b/match/misc/example_settings.json
@@ -9,6 +9,7 @@
                                 "matchDay": "4",
                                 "matchDate": "July 6, 2022",
                                 "matchType": "Regular Season",
+                                "matchFormat": "4-gs",
                                 "home": "Gorillas",
                                 "away": "Peppermint",
                                 "roomName": "badlands",
@@ -18,6 +19,7 @@
                                 "matchDay": "4",
                                 "matchDate": "May 25, 2022",
                                 "matchType": "Regular Season",
+                                "matchFormat": "4-gs",
                                 "home": "Thermal",
                                 "away": "Gorillas",
                                 "roomName": "fury",
@@ -33,6 +35,7 @@
                                     "forfeits": [
                                         {
                                             "team": "Gorillas",
+                                            "game_no": 1,
                                             "game_by_time": "2022-07-14 06:49 UTC"
                                         }
                                     ]
@@ -42,8 +45,14 @@
                     }
                 },
                 "LobbyHashes": {
-                    "1": [-8600427675859063065, 7192519824993810708],
-                    "2": [4301634076316122128, 6282479947756218303]
+                    "1": [
+                        -8600427675859063065,
+                        7192519824993810708
+                    ],
+                    "2": [
+                        4301634076316122128,
+                        6282479947756218303
+                    ]
                 },
                 "MatchDay": "4"
             }

--- a/match/misc/example_settings.json
+++ b/match/misc/example_settings.json
@@ -27,7 +27,15 @@
                                     "home_wins": 4,
                                     "away_wins": 0,
                                     "summary": "**Thermal** 4 - 0 **Gorillas**",
-                                    "ballchasing_link": "https://ballchasing.com/group/thermal-vs-gorillas-ljbshz1yd9"
+                                    "ballchasing_id": "thermal-vs-gorillas-ljbshz1yd9",
+                                    "ballchasing_link": "https://ballchasing.com/group/thermal-vs-gorillas-ljbshz1yd9",
+                                    "message_report_ids": [],
+                                    "forfeits": [
+                                        {
+                                            "team": "Gorillas",
+                                            "game_by_time": "2022-07-14 06:49 UTC"
+                                        }
+                                    ]
                                 }
                             }
                         ]

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -1066,7 +1066,7 @@ class TeamManager(commands.Cog):
         await self.config.guild(ctx.guild).Team_Roles.set(team_roles)
 
     def _find_role(self, ctx, role_id):
-        for role in ctx.message.guild.roles:
+        for role in ctx.guild.roles:
             if role.id == role_id:
                 return role
         raise LookupError(

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -1235,6 +1235,7 @@ class TeamManager(commands.Cog):
             for emoji in emojis:
                 if emoji.name.lower() == prefix.lower() or emoji.name.lower() == gm_name.lower():
                     return emoji
+        return None
 
     def _get_gm(self, ctx, franchise_role):
         for member in ctx.message.guild.members:


### PR DESCRIPTION
# bcManager
- Enables getting and setting of statsManager role. Enables stats managers to execute necessary maintenance commands
- Includes match day param to `bcr` command
- Adds `manualMatchUpdate <ballchasing link>` to have a scoreline updated based on what exists at the provided group linked
- Adds `manualMatchReport <match day> <team a> <team a wins> <team b> <team b wins>` to manually report a match apart from a ballchasing group
- Adds `reportForfeit <match day> <team a> <team b>` to update match for forfeited match games with Embed/Reaction menu
- Adds support for RSC web app tokens
- Updates set token command name for ballchasing
- Updates code to use accounts from RSC web service