### PR TITLE
Ballchasy

### DIFF
--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -1088,7 +1088,7 @@ class BCManager(commands.Cog):
             tier_group = await self.get_tier_subgroup_name(ctx.guild, tier)
             top_level_group = await self._get_top_level_group(ctx.guild)
             ordered_subgroup_names = [
-                match.get("match_type", "Regular Season"),
+                # match.get("match_type", "Regular Season"), # TODO: Match Type Removed for the remainder of Season 15 - can't move RSC subgroups
                 tier_group,
                 f"Match Day {str(match['matchDay']).zfill(2)}",
                 f"{match['home']} vs {match['away']}"

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -483,7 +483,12 @@ class BCManager(commands.Cog):
         group_code = await self._get_top_level_group(ctx.guild)
         url = f"https://ballchasing.com/group/{group_code}"
         if group_code:
-            await ctx.send(f"See all season replays in the top level ballchasing group: {url}")
+            embed = discord.Embed(title="RSC Ballchasing Group", description=f"[Click to view]({url})", color=discord.Color.blue())
+            
+            if ctx.guild.icon_url:
+                embed.set_thumbnail(url=ctx.guild.icon_url)
+
+            await ctx.send(embed=embed)
         else:
             await ctx.send(":x: A ballchasing group has not been set for this season.")
 

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -803,7 +803,7 @@ class BCManager(commands.Cog):
             return await self.finalize_ff_report(guild, message, emoji)
 
         # Capture previously ff games
-        forfeits = match['report'].get('forfeits')
+        forfeits = match['report'].get('forfeits', [])
         if forfeits:
             locked_ffs = [f"{ff['ff_team']} FF Game {ff['game_num']}" for ff in forfeits]
         else:

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -250,7 +250,6 @@ class BCManager(commands.Cog):
         guild_emoji_url = ctx.guild.icon_url
         channels = list(set([ctx.channel, (await self._get_log_channel(ctx.guild))]))
         status_messages = await self.send_ram_message(channels, self.get_bc_match_day_status_report(match_day, bc_report_summary_json, guild_emoji_url))
-        # TODO: remove: processing_status_msg = await ctx.send(embed=self.get_bc_match_day_status_report(match_day, bc_report_summary_json, guild_emoji_url))
 
         # Process/Report All Replays
         for tier_role in tier_roles:
@@ -260,9 +259,10 @@ class BCManager(commands.Cog):
             tier_report_channel = await self.get_score_reporting_channel(tier_role)
             for match in schedule.get(tier_role.name, {}).get(match_day, []):
                 match_group_info = {}
+
                 # update status message
-                # TODO: remove: await processing_status_msg.edit(embed=self.get_bc_match_day_status_report(match_day, bc_report_summary_json, guild_emoji_url))
                 await self.update_messages(status_messages, embed=self.get_bc_match_day_status_report(match_day, bc_report_summary_json, guild_emoji_url))
+                
                 # update status embed
                 bc_report_summary_json[tier_role]['index'] += 1
                 
@@ -292,7 +292,6 @@ class BCManager(commands.Cog):
             bc_report_summary_json[tier_role]['active'] = False
         
         # update status message
-        # TODO: remove: await processing_status_msg.edit(embed=self.get_bc_match_day_status_report(match_day, bc_report_summary_json, emoji_url=guild_emoji_url, complete=True))
         await self.update_messages(status_messages, embed=self.get_bc_match_day_status_report(match_day, bc_report_summary_json, emoji_url=guild_emoji_url, complete=True))     
     
     @commands.command(aliases=['rff', 'reportFF'])
@@ -375,8 +374,6 @@ class BCManager(commands.Cog):
             return await ctx.reply(f":x: This is not a valid result set for the format `{match['matchFormat']}`")
         
         match = await self.update_match_report(ctx, tier_role.name, match, report)
-        
-        # TODO: if match was previously reported, should replays persist?
 
         await ctx.reply(DONE)
 
@@ -1383,7 +1380,8 @@ class BCManager(commands.Cog):
         match['report'] = report
         return match
 
-    # TODO: UPDATE match summary -- Note: if report_channel is NOT provided, then this is called from bcr
+    # TODO: UPDATE match summary (similar)
+    # Note: if report_channel is NOT provided, then this is called from bcr
     async def send_match_summary(self, ctx, match, score_report_channel: discord.TextChannel=None):
         
         title = f"MD {match['matchDay']}: {match['home']} vs {match['away']}"
@@ -1551,7 +1549,7 @@ class BCManager(commands.Cog):
 
         return hash(hash_input_str)
 
-    # TODO: resolve 14 game bug
+    # TODO: validate resolution to 12-14 game bug from reportAllMatches
     async def get_all_match_players(self, ctx, match_info):
         all_players = []
         

--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -675,7 +675,8 @@ class BCManager(commands.Cog):
         
         # Step 4: Send updated embed (Status: found, uploading)
         embed.description = "Match Summary:\n{}\n{}".format(discovery_data.get('summary'), FOUND_AND_UPLOADING)
-        await bc_status_msg.edit(embed=embed)
+        if single_player_call:
+            await bc_status_msg.edit(embed=embed)
         
         # Find or create ballchasing subgroup
         match_subgroup_json = await self.get_replay_destination(ctx, match, tier_md_group_code=tier_md_group_code)
@@ -688,7 +689,8 @@ class BCManager(commands.Cog):
 
         # Step 5: Group created, Finalize embed
         embed.description = SUCCESS_EMBED.format(discovery_data.get('summary'), match_subgroup_json.get('link'))
-        await bc_status_msg.edit(embed=embed)
+        if single_player_call:
+            await bc_status_msg.edit(embed=embed)
         match_report_message = await score_report_channel.send(embed=embed)
 
         # Step 6: Update match cog info

--- a/match/match.py
+++ b/match/match.py
@@ -155,7 +155,7 @@ class Match(commands.Cog):
     # endregion
 
 # General Info Commands
-    @commands.command()
+    @commands.command(aliases=['gmd'])
     @commands.guild_only()
     async def getMatchDay(self, ctx):
         """Gets the currently active match day."""
@@ -164,8 +164,7 @@ class Match(commands.Cog):
             await ctx.send(
                 "Current match day is: {0}".format(match_day))
         else:
-            await ctx.send(":x: Match day not set. Set with setMatchDay "
-                           "command.")
+            await ctx.send(":x: Match day not set. Set with setMatchDay command.")
 
 # Player Commands
     @commands.command()

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -763,7 +763,7 @@ class TeamManager(commands.Cog):
         indicated by the provided franchise_role and tier_role.
         """
         team_members = []
-        for member in ctx.message.guild.members:
+        for member in ctx.guild.members:
             if franchise_role in member.roles:
                 if tier_role in member.roles:
                     team_members.append(member)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -763,10 +763,9 @@ class TeamManager(commands.Cog):
         indicated by the provided franchise_role and tier_role.
         """
         team_members = []
-        for member in ctx.guild.members:
-            if franchise_role in member.roles:
-                if tier_role in member.roles:
-                    team_members.append(member)
+        for member in franchise_role.members:
+            if tier_role in member.roles:
+                team_members.append(member)
         return team_members
 
     async def create_roster_embed(self, ctx, team_name):


### PR DESCRIPTION
# bcManager
- adds score report message id to match report to avoid duplicate score reports
- updates embeds to be more concise in title and descriptions
- puts bcGroup command in an embed response
- fixes bug where `<p>tokencheck` always reports RSC token as valid and registered
- updates code to only clear top level group when new ballchasing token owner is inconsistent with existing top level group owner
- Removes old and ugly TODOs
- Fixes `<p>reportForfeit` confirmation bug
- **TEMPORARY** removal of `match_type` (Regular Season, Playoffs, etc) due to inability for RSC staff to move existing replay groups -- plan to add this subgroup for S16

# match
- adds `<p>gmd` as a reference to `<p>getMatchDay`

# teamManager
- optimizes `get_players_for_team`, which may fix `bcManager`'s `<p>reportAllMatches` command
