### PR TITLE
Updated guild.icon_url to new standard guild.icon.url and fixed thumb…

### DIFF
--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -257,7 +257,7 @@ class BCManager(commands.Cog):
         
         # endregion
 
-        guild_emoji_url = ctx.guild.icon_url
+        guild_emoji_url = ctx.guild.icon.url
         channels = list(set([ctx.channel, (await self._get_log_channel(ctx.guild))]))
         # start_time = ctx.message.created_at
         start_time = datetime.now()
@@ -349,7 +349,7 @@ class BCManager(commands.Cog):
             }
         # endregion
 
-        guild_emoji_url = ctx.guild.icon_url
+        guild_emoji_url = ctx.guild.icon.url
         channels = list(set([ctx.channel, (await self._get_log_channel(ctx.guild))]))
         # start_time = ctx.message.created_at
         start_time = datetime.now()
@@ -580,8 +580,8 @@ class BCManager(commands.Cog):
         if group_code:
             embed = discord.Embed(title="RSC Ballchasing Group", description=f"[Click to view]({url})", color=discord.Color.blue())
             
-            if ctx.guild.icon_url:
-                embed.set_thumbnail(url=ctx.guild.icon_url)
+            if ctx.guild.icons.url:
+                embed.set_thumbnail(url=ctx.guild.icon.url)
 
             await ctx.send(embed=embed)
         else:
@@ -608,9 +608,9 @@ class BCManager(commands.Cog):
         if franchise_role:
             accounts_embed.set_thumbnail(url=(await self.team_manager_cog.get_franchise_emoji_url(ctx, franchise_role)))
         else:
-            accounts_embed.set_thumbnail(url=ctx.guild.icon_url)
+            accounts_embed.set_thumbnail(url=ctx.guild.icon.url)
         
-        accounts_embed.set_footer(icon_url=ctx.guild.icon_url, text="RSC Tracker Links: https://tinyurl.com/TrackerLinks")
+        accounts_embed.set_footer(icon_url=ctx.guild.icon.url, text="RSC Tracker Links: https://tinyurl.com/TrackerLinks")
 
         msg : discord.Message = await ctx.send(embed=accounts_embed)
         linked_accounts = []
@@ -728,7 +728,7 @@ class BCManager(commands.Cog):
         # Step 2: Send initial embed (Searching...)
         match_day: int = match['matchDay']
         franchise_role, tier_role = await self.team_manager_cog._roles_for_team(ctx, match['home'])
-        emoji_url = ctx.guild.icon_url
+        emoji_url = ctx.guild.icon.url
 
         score_report_embed = discord.Embed(
             title=f"MD {match_day}: {match['home']} vs {match['away']}",
@@ -1033,17 +1033,17 @@ class BCManager(commands.Cog):
             if home_emoji:
                 embed.set_thumbnail(url=home_emoji.url)
             else:
-                embed.set_thumbnail(url=guild.icon_url)
+                embed.set_thumbnail(url=guild.icon.url)
         elif home_wins < away_wins:
             winner = match['away']
             away_emoji = self.ffp[guild][message]['deep_match_report']['away_emoji']
             if away_emoji:
                 embed.set_thumbnail(url=away_emoji.url)
             else:
-                embed.set_thumbnail(url=guild.icon_url)
+                embed.set_thumbnail(url=guild.icon.url)
         else:
             winner = None
-            embed.set_thumbnail(url=guild.icon_url)
+            embed.set_thumbnail(url=guild.icon.url)
         
         # update match info
         match['report']['summary'] = f"**{match['home']}** {home_wins} - {away_wins} **{match['away']}**"
@@ -1544,7 +1544,7 @@ class BCManager(commands.Cog):
             emoji_url = await self.team_manager_cog.get_franchise_emoji_url(ctx, franchise_role)
         else:
             franchise_role, tier_role = await self.team_manager_cog._roles_for_team(ctx, match['home'])
-            emoji_url = ctx.guild.icon_url
+            emoji_url = ctx.guild.icon.url
 
         summary = f"**{match['home']}** {report.get('home_wins', 0)} - {report.get('away_wins', 0)} **{match['away']}**"
         SUCCESS_EMBED = "Match Summary:\n{}\n\n[View group on ballchasing!]({})"
@@ -1911,7 +1911,7 @@ class BCManager(commands.Cog):
             emoji_url = await self.team_manager_cog.get_franchise_emoji_url(ctx, franchise_role)
         else:
             franchise_role, tier_role = await self.team_manager_cog._roles_for_team(ctx, match['home'])
-            emoji_url = ctx.guild.icon_url
+            emoji_url = ctx.guild.icon.url
         
         return tier_role, emoji_url
 

--- a/faCheckIn/faCheckIn.py
+++ b/faCheckIn/faCheckIn.py
@@ -86,7 +86,8 @@ class FaCheckIn(commands.Cog):
             if role.name.lower() == tier_name.lower():
                 color = role.color
         embed = discord.Embed(title="Availability for {0} tier on match day {1}:".format(tier, match_day), color=color, 
-            description=message, thumbnail=ctx.guild.icon_url)
+            description=message)
+        embed.set_thumbnail(url=ctx.guild.icon.url)
                     
         await ctx.send(embed=embed)
 

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -542,7 +542,7 @@ class ModeratorLink(commands.Cog):
             color=discord.Color.red(),
             description=message,
         )
-        embed.set_thumbnail(url=guild.icon_url)
+        embed.set_thumbnail(url=guild.icon.url)
 
         # Send message to kicked/banned member
         try:

--- a/statsManager/statsManager.py
+++ b/statsManager/statsManager.py
@@ -210,7 +210,7 @@ class StatsManager(commands.Cog):
         if emoji:
             embed.set_thumbnail(url=emoji.url)
         else:
-            embed.set_thumbnail(url=ctx.guild.icon_url)
+            embed.set_thumbnail(url=ctx.guild.icon.url)
         
         team_info = ""
         team_info += f"**Tier:** {tier_role.mention}"
@@ -244,7 +244,7 @@ class StatsManager(commands.Cog):
         if emoji:
             embed.set_thumbnail(url=emoji.url)
         else:
-            embed.set_thumbnail(url=ctx.guild.icon_url)
+            embed.set_thumbnail(url=ctx.guild.icon.url)
         
         # Team Info
         team_info = f"**Tier:** {tier_role.mention}"

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -392,11 +392,11 @@ class TeamManager(commands.Cog):
             gms.append(gm_name)
 
         embed = discord.Embed(
-            title="Franchises", color=discord.Colour.blue(), thumbnail=ctx.guild.icon_url)
+            title="Franchises", color=discord.Colour.blue())
         embed.add_field(name="Pfx.", value="{}\n".format("\n".join(prefixes)), inline=True)
         embed.add_field(name="Franchise", value="{}\n".format("\n".join(franchises)), inline=True)
         embed.add_field(name="General Manager", value="{}\n".format("\n".join(gms)), inline=True)
-        embed.set_thumbnail(url=ctx.guild.icon_url)
+        embed.set_thumbnail(url=ctx.guild.icon.url)
         await ctx.send(embed=embed)
 
     @commands.command()
@@ -604,7 +604,8 @@ class TeamManager(commands.Cog):
             if role.name.lower() == tier_name.lower():
                 color = role.color
         embed = discord.Embed(title="{0} Free Agents".format(tier_name), color=color,
-                              description=message, thumbnail=ctx.guild.icon_url)
+                              description=message)
+        embed.set_thumbnail(url=ctx.guild.icon)
 
         await ctx.send(embed=embed)
 
@@ -782,7 +783,7 @@ class TeamManager(commands.Cog):
         if emoji:
             embed.set_thumbnail(url=emoji.url)
         else:
-            embed.set_thumbnail(url=ctx.guild.icon_url)
+            embed.set_thumbnail(url=ctx.guild.icon.url)
         return embed
 
     async def format_roster_info(self, ctx, team_name: str):
@@ -849,7 +850,7 @@ class TeamManager(commands.Cog):
         if emoji:
             embed.set_thumbnail(url=emoji.url)
         else:
-            embed.set_thumbnail(url=ctx.guild.icon_url)
+            embed.set_thumbnail(url=ctx.guild.icon.url)
         return embed
 
     async def _format_tier_captains(self, ctx, tier: str):
@@ -937,7 +938,7 @@ class TeamManager(commands.Cog):
         if emoji:
             embed.set_thumbnail(url=emoji.url)
         else:
-            embed.set_thumbnail(url=ctx.guild.icon_url)
+            embed.set_thumbnail(url=ctx.guild.icon.url)
         return embed
 
     async def _format_teams_for_tier(self, ctx, tier):
@@ -962,7 +963,7 @@ class TeamManager(commands.Cog):
             embed.add_field(name="Franchise", value="{}\n".format("\n".join(franchises)), inline=True)
         else:
             embed.description = "No teams have been set up for this tier."
-        embed.set_thumbnail(url=ctx.guild.icon_url)
+        embed.set_thumbnail(url=ctx.guild.icon.url)
         return embed
 
     async def tier_roles(self, ctx):
@@ -1253,7 +1254,7 @@ class TeamManager(commands.Cog):
         if emoji:
             return emoji.url
 
-        guild_icon_url = franchise_role.guild.icon_url
+        guild_icon_url = franchise_role.guild.icon.url
         if guild_icon_url:
             return guild_icon_url
         

--- a/transactions/transactions.py
+++ b/transactions/transactions.py
@@ -505,7 +505,7 @@ class Transactions(commands.Cog):
         )
         
         try:
-            embed.set_thumbnail(url=ctx.guild.icon_url)
+            embed.set_thumbnail(url=ctx.guild.icon.url)
         except:
             pass
         
@@ -598,8 +598,8 @@ class Transactions(commands.Cog):
         )
         
         embed = discord.Embed(title=f"Notice from {ctx.guild.name}", description=msg, color=discord.Color.blue())
-        if ctx.guild.icon_url:
-            embed.set_thumbnail(url=ctx.guild.icon_url)
+        if ctx.guild.icon.url:
+            embed.set_thumbnail(url=ctx.guild.icon.url)
 
         await self.dm_helper_cog.add_to_dm_queue(member=player, embed=embed, ctx=ctx)
 


### PR DESCRIPTION
`guild.icon_url` has been replaced with `guild.icon` in the new discord.py. (https://discordpy.readthedocs.io/en/v2.2.3/migrating.html#asset-redesign-and-changes)

Fixed embed thumbnails. Thumbnail is not a property for creating a Discord.Embed object.