### PR TITLE
datetime objects are now UTC-Aware swapping to discord.py helper func…

### DIFF
--- a/match/match.py
+++ b/match/match.py
@@ -535,7 +535,7 @@ class Match(commands.Cog):
                 if activity.name == game:
                     playing = True
                     try:
-                        playing = not activity.end or activity.end > datetime.utcnow()
+                        playing = not activity.end or activity.end > discord.utils.utcnow()
                     except:
                         playing = not activity.end
                     return playing

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -346,7 +346,7 @@ class ModeratorLink(commands.Cog):
         except:
             after_name = after.name
         
-        seconds_in_server = (datetime.utcnow() - before.joined_at).seconds
+        seconds_in_server = (discord.utils.utcnow() - before.joined_at).seconds
         if before_name != after_name and seconds_in_server > 120:
             await self._process_nickname_update(before, after)
             
@@ -475,7 +475,7 @@ class ModeratorLink(commands.Cog):
 
         # SUSPICIOUS NEW ACCOUNTS
         for blacklist_name in await self._get_blacklisted_names(member.guild):  # await self._get_name_blacklist():
-            account_age = (datetime.utcnow() - member.created_at).seconds
+            account_age = (discord.utils.utcnow() - member.created_at).seconds
             if blacklist_name in member.name.lower() and account_age <= ACC_AGE_THRESHOLD + 10:
                 await self.process_bot_member_kick(member, reason=SUS_NEW_ACC_BT)
                 return True


### PR DESCRIPTION
https://discordpy.readthedocs.io/en/v2.2.3/migrating.html#datetime-objects-are-now-utc-aware

This needs to be swapped since timezone is taken into account now. See link above for migration notes.

The discord.py helper function `discord.utils.utcnow()` is ideal and returns `datetime.datetime.now(datetime.timezone.utc)` instead.