### PR TITLE
Falls back to 'user.global_name' if 'user.nick' has not been set.

### DIFF
--- a/bulkRoleManager/bulkRoleManager.py
+++ b/bulkRoleManager/bulkRoleManager.py
@@ -773,6 +773,9 @@ class BulkRoleManager(commands.Cog):
             else:
                 currentNickname = array[0]
             return currentNickname
+        elif user.global_name:
+            return user.global_name
+
         return user.name
 
     async def _draft_eligible_message(self, ctx):


### PR DESCRIPTION
1. This fixes a bug where `get_nick_name()` will fail to grab the players nickname if it hasn't been set in the server. 

With the new discord username mechanism, a user joining our server now has their "display name" set in discord.Member.global_name instead of defaulting to what was in their username.

If a nickname isn't set by us, then any call to get_nickname will fail to show the correct user in `?getId`

