### PR TITLE
Fix getId to use global_name

### DIFF
--- a/bulkRoleManager/bulkRoleManager.py
+++ b/bulkRoleManager/bulkRoleManager.py
@@ -773,10 +773,8 @@ class BulkRoleManager(commands.Cog):
             else:
                 currentNickname = array[0]
             return currentNickname
-        elif user.global_name:
-            return user.global_name
 
-        return user.name
+        return user.global_name
 
     async def _draft_eligible_message(self, ctx):
         return await self.config.guild(ctx.guild).DraftEligibleMessage()

--- a/bulkRoleManager/bulkRoleManager.py
+++ b/bulkRoleManager/bulkRoleManager.py
@@ -773,6 +773,9 @@ class BulkRoleManager(commands.Cog):
             else:
                 currentNickname = array[0]
             return currentNickname
+        elif user.global_name:
+            return user.global_name
+
         return user.name
 
     async def _draft_eligible_message(self, ctx):


### PR DESCRIPTION
Since the discord name style has changed, there was no way to get the global nickname for a user. Discordpy 2.3 now supports that with global_name