### PR TITLE
Changes ?makeFA and ?expireContracts to be runnable by TM members

### DIFF
--- a/transactions/transactions.py
+++ b/transactions/transactions.py
@@ -57,7 +57,7 @@ class Transactions(commands.Cog):
 
     @commands.command(aliases=['makeFA'])
     @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
+    @checks.admin_or_permissions(manage_roles=True)
     async def expireContracts(self, ctx: commands.Context, *userList):
         """Displays each member that can be found from the userList a Free Agent in their respective tier"""
         empty = True


### PR DESCRIPTION
Hey nick, simple super-high-priority permissions change to one of the transaction commands. ?makeFA was currently limited to just "manage guild" roles --> admins and Reverse Fridge. TMs need to be able to `?makeFA` people manually sometimes.