### PR TITLE
Fix old Guild.icon_url reference. This was replaced by Guild.icon

### DIFF
--- a/bcManager/bcManager.py
+++ b/bcManager/bcManager.py
@@ -918,7 +918,7 @@ class BCManager(commands.Cog):
                     )
                 )
             )
-        elif ctx.guild.icon_url:
+        elif ctx.guild.icon:
             accounts_embed.set_thumbnail(url=ctx.guild.icon.url)
 
         # Footer with tracker link. Footer expects string and will not handle `NoneType`


### PR DESCRIPTION
Fix old Guild.icon_url reference. This was replaced by Guild.icon in discordpy v2.3