### PR TITLE
Transactions: Settings group and rostered player leaves

### DIFF
--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -1246,7 +1246,7 @@ class TeamManager(commands.Cog):
         for team in teams:
             if await self._roles_for_team(ctx, team) == (franchise_role, tier_role):
                 return team
-        return
+        return None
 
     async def _find_teams_for_franchise(self, ctx, franchise_role):
         franchise_teams = []


### PR DESCRIPTION
Revamped transactions a bit.

- Moved all settings into a group command `?transactions`
- The group command will handle viewing current settings, configuring them, and removing them
- Added transaction log and role settings
- Listener for `on_member_remove` which tracks if a user was removed or left the discord. This will check if the player was rostered on a franchise and notifies transaction committee